### PR TITLE
Migrado para .NET Standards 2.0 e ajustado para respeitar https://rul…

### DIFF
--- a/Source/Otc.DomainBase.Exceptions/CoreException.cs
+++ b/Source/Otc.DomainBase.Exceptions/CoreException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Otc.DomainBase.Exceptions
 {
@@ -11,10 +12,11 @@ namespace Otc.DomainBase.Exceptions
 
         }
 
-        [Obsolete("Utilize a propriedade Key. Na proxima versao esta propriedade pode deixar de existir.")]
-        public virtual string TypeName => GetType().Name;
+        protected CoreException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
 
-        public virtual string Key => TypeName;
+        public abstract string Key { get; }
     }
 
     public abstract class CoreException<T> : CoreException
@@ -30,6 +32,10 @@ namespace Otc.DomainBase.Exceptions
             : base(message)
         {
 
+        }
+
+        protected CoreException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
         }
 
         public ICollection<T> Errors { get; } = new List<T>();

--- a/Source/Otc.DomainBase.Exceptions/ModelValidationException.cs
+++ b/Source/Otc.DomainBase.Exceptions/ModelValidationException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Otc.DomainBase.Exceptions
 {
+    [Serializable]
     public class ModelValidationException : CoreException<ModelValidationError>
     {
         public ModelValidationException()
@@ -14,8 +16,10 @@ namespace Otc.DomainBase.Exceptions
             AddError(errors);
         }
 
-        [Obsolete("Utilize a propriedade Key. Na proxima versao esta propriedade pode deixar de existir.")]
-        public override string TypeName => "ModelValidationException";
+        protected ModelValidationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
         public override string Key => "ModelValidationException";
     }
 }

--- a/Source/Otc.DomainBase.Exceptions/Otc.DomainBase.Exceptions.csproj
+++ b/Source/Otc.DomainBase.Exceptions/Otc.DomainBase.Exceptions.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Ole Consignado</Authors>
     <Company>Ole Consignado</Company>
     <Description>Starting point of DDD based domain layer project for Ole Consignado. Provides base domain exception types.</Description>


### PR DESCRIPTION
**Breaking Changes**
* `CoreException.TypeName` replaced by `CoreException.Key` abstract property.

**No-breaking**
* Update to .NET Standards 2.0
* Adjusted to respect https://rules.sonarsource.com/csharp/RSPEC-3925
