### PR TITLE
Correção de erro em desserialização de exceções do tipo CoreException.

### DIFF
--- a/Source/Otc.DomainBase.Exceptions/CoreException.cs
+++ b/Source/Otc.DomainBase.Exceptions/CoreException.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 
 namespace Otc.DomainBase.Exceptions
 {
+    [Serializable]
     public abstract class CoreException : Exception
     {
         protected CoreException(string message)
@@ -23,6 +24,7 @@ namespace Otc.DomainBase.Exceptions
         public IEnumerable<CoreError> Errors { get { return errors; } }
     }
 
+    [Serializable]
     public abstract class CoreException<T> : CoreException
         where T : CoreError
     {


### PR DESCRIPTION
Pessoal,
Construindo os testes de contrato de API percebi que ocorria um erro ao tentar desserializar a resposta em classes especializadas de _CoreException_. Então percebi que não tinha sido adicionado o atributo _Serializable_ na definição da classe, o que depois de implementado passou a resolver o problema.